### PR TITLE
>512 token-related crash fix

### DIFF
--- a/germansentiment/sentimentmodel.py
+++ b/germansentiment/sentimentmodel.py
@@ -21,7 +21,8 @@ class SentimentModel():
     def predict_sentiment(self, texts: List[str])-> List[str]:
         texts = [self.clean_text(text) for text in texts]
         # Add special tokens takes care of adding [CLS], [SEP], <s>... tokens in the right way for each model.
-        input_ids = self.tokenizer.batch_encode_plus(texts,padding=True, add_special_tokens=True)
+        # limit number of tokens to model's limitations (512)
+        input_ids = self.tokenizer.batch_encode_plus(texts,padding=True, add_special_tokens=True,truncation=True,max_length=512)
         input_ids = torch.tensor(input_ids["input_ids"])
         input_ids = input_ids.to(self.device)
 


### PR DESCRIPTION
last two parameters added to _self.tokenizer.batch_encode_plus()_ in order to limit maximum number of tokens in case of long strings to prevent crashes with the following error message:
```
Token indices sequence length is longer than the specified maximum sequence length for this model (603 > 512). 
Running this sequence through the model will result in indexing errors
```

this fix increases the stability of the script for longer natural texts.